### PR TITLE
Use newer version of rise and revert workaround.

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -23,10 +23,7 @@ RUN pip install otter-grader \
     torchaudio \
     Scrapy
 
-RUN echo -e '#!/bin/bash\n\njupyter notebook extension $@' > /opt/conda/bin/jupyter-nbextension && \
-    chmod +x /opt/conda/bin/jupyter-nbextension
-
-RUN mamba install -c conda-forge rise altair
+RUN mamba install -c conda-forge jupyterlab_rise altair
 
 ENV TZ America/Los_Angeles
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone


### PR DESCRIPTION
Revert hack from last PR and use jupyter's fork of Rise compatible with newer Jupyter notebooks.