### PR TITLE
Quarto Requirements

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -21,10 +21,7 @@ RUN pip install otter-grader \
     geopandas \
     folium
 
-RUN conda install -y -c conda-forge jupyterlab_rise altair
-
-RUN R -e "install.packages(c('glmnet', 'quarto', 'reticulate', 'rocr', 'spotifyr'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
-
+RUN conda install -y -c conda-forge jupyterlab_rise altair r-glmnet r-reticulate r-rocr r-spotifyr
 
 ENV TZ America/Los_Angeles
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/Containerfile
+++ b/Containerfile
@@ -21,7 +21,10 @@ RUN pip install otter-grader \
     geopandas \
     folium
 
-RUN conda install -y -c conda-forge jupyterlab_rise altair r-glmnet r-quarto r-reticulate r-rocr r-spotifyr
+RUN conda install -y -c conda-forge jupyterlab_rise altair
+
+RUN R -e "install.packages(c('glmnet', 'quarto', 'reticulate', 'rocr', 'spotifyr'), repos = 'https://cloud.r-project.org/', Ncpus = parallel::detectCores())"
+
 
 ENV TZ America/Los_Angeles
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,6 @@ pipeline {
                         sh 'podman run -it --rm localhost/$IMAGE_NAME which rstudio'
                         sh 'podman run -it --rm localhost/$IMAGE_NAME which xelatex'
 			sh 'podman run -it --rm localhost/$IMAGE_NAME otter --version'
-                        sh 'podman run -it --rm localhost/$IMAGE_NAME quarto --version'
                         sh 'podman run -it --rm localhost/$IMAGE_NAME R -q -e "getRversion() >= \\"4.1.3\\"" | tee /dev/stderr | grep -q "TRUE"'
                         sh 'podman run -it --rm localhost/$IMAGE_NAME python -c "import numpy; import pandas; import altair; import matplotlib; import sklearn; sklearn.show_versions(); import scipy; import seaborn; import statsmodels; import cvxpy; import geopandas; import pyarrow; import folium"'
                         sh 'podman run -it --rm localhost/$IMAGE_NAME R -e "library(\"ROCR\");library(\"glmnet\");library(\"quarto\");library(\"reticulate\");library(\"spotifyr\")"'


### PR DESCRIPTION
Turns out the quarto requirement is for use inside RStudio. 


RStudio ships it's own quarto binary. Installing the CLI binary messes up RStudio. Even though it's importing other paths, the RStudio version doesn't grok the other changes added by the conda install. 


So we're not installing quarto, as it's not that kind of requirement. Doing that allows renders to happen without errors. 